### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Something is not working as expected
+labels: bug
+---
+
+## Description
+<!-- What happens and what should happen instead -->
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Expected behavior
+<!-- What you expected to happen -->
+
+## Actual behavior
+<!-- What actually happens -->
+
+## Additional context
+<!-- Screenshots, logs, etc. (optional) -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Propose an improvement or new feature
+labels: enhancement
+---
+
+## Problem to solve
+<!-- What problem does this feature address? Who is affected and how? -->
+
+## Proposed solution
+<!-- Describe how you would implement it -->
+
+## Additional context
+<!-- Mockups, references, related issues, etc. (optional) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- Brief description of the change and its motivation -->
+
+## Solution
+<!-- Describe the approach taken and why -->
+
+## Related issue
+Closes #
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Docs / config
+
+## Solution
+<!-- Describe the approach taken and why -->
+
+## Checklist
+- [ ] Tests pass
+- [ ] Manually tested the change
+- [ ] No unintended side effects on other features

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # End of https://www.toptal.com/developers/gitignore/api/django


### PR DESCRIPTION
## Summary
Add standard templates for issues and pull requests to ensure consistent and structured contributions.

## Solution
Created three templates under `.github/`:
- `ISSUE_TEMPLATE/bug_report.md`
- `ISSUE_TEMPLATE/feature_request.md`
- `PULL_REQUEST_TEMPLATE.md`

## Related issue
Closes #1

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / config

## Checklist
- [x] Tests pass
- [x] Manually tested the change
- [x] No unintended side effects on other features