### PR TITLE
Config pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ asgiref==3.11.1
 Django==5.2.13
 sqlparse==0.5.5
 ruff==0.15.12
+pre-commit==4.6.0
 mypy==1.20.2
 django-stubs==5.2.0


### PR DESCRIPTION
## Summary
Adds pre-commit with Ruff hooks so developers get immediate local feedback before each commit.

## Solution
Adds `.pre-commit-config.yaml` with Ruff's official hooks (`ruff check --fix` and `ruff-format`), and pins `pre-commit==4.6.0` in `requirements.txt`. mypy is intentionally excluded — it stays in CI only.

## Related issue
Closes #11

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / config

## Checklist
- [ ] Tests pass
- [x] Manually tested the change
- [x] No unintended side effects on other features