### PR TITLE
feat: add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+.env
+venv/
+__pycache__/
+*.pyc
+.mypy_cache/
+db.sqlite3

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Django
+SECRET_KEY=your-secret-key-here
+DEBUG=True
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# PostgreSQL
+POSTGRES_DB=truqui_center
+POSTGRES_USER=truqui
+POSTGRES_PASSWORD=truqui
+POSTGRES_HOST=db
+POSTGRES_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
           python-version: "3.12"
       - run: pip install -r requirements.txt
       - run: mypy .
+        env:
+          SECRET_KEY: ci-dummy-secret-key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16
+    env_file:
+      - .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.11.1
 Django==5.2.13
 sqlparse==0.5.5
+psycopg2-binary==2.9.12
 ruff==0.15.12
 pre-commit==4.6.0
 mypy==1.20.2

--- a/truqui_center/settings.py
+++ b/truqui_center/settings.py
@@ -10,22 +10,16 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+SECRET_KEY = os.environ["SECRET_KEY"]
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
+DEBUG = os.environ.get("DEBUG", "False") == "True"
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-)rr!%47%w%&c3a4e@94xe%925v+0o!*kjy^pe8c^aqn2)!y)z_"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS: list[str] = []
+ALLOWED_HOSTS = [h for h in os.environ.get("ALLOWED_HOSTS", "").split(",") if h]
 
 
 # Application definition
@@ -74,8 +68,12 @@ WSGI_APPLICATION = "truqui_center.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", ""),
+        "USER": os.environ.get("POSTGRES_USER", ""),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", ""),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
     }
 }
 


### PR DESCRIPTION
## Summary

Add a fully working Docker development environment with PostgreSQL, and adapt Django settings to read configuration from environment variables.

## Solution

- Add `Dockerfile`, `docker-compose.yml`, `.dockerignore`, and `.env.example` to define and run the development environment with `docker compose up`
- Add `psycopg2-binary` as the PostgreSQL driver
- Replace hardcoded values in `settings.py` (`SECRET_KEY`, `DEBUG`, database config) with `os.environ` reads
- Fix `pg_isready` healthcheck to target the correct database with `-d ${POSTGRES_DB}`

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / config

## Checklist

- [ ] Tests pass
- [x] Manually tested the change
- [x] No unintended side effects on other features