### PR TITLE
feat: post list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ The ORM is allowed at all layers as a pragmatic exception.
 
 ## Modules
 
+### Pages
+
+Static pages are available at:
+
+| URL | View | Description |
+|---|---|---|
+| `/<slug>/` | `PageDetailView` | Full page detail |
+
+Pages are managed via the Django admin (`/admin/` → **Pages**). A page only appears on the site when `is_published` is set to `True`.
+
+#### Adding a Page to the navigation menu
+
+To expose a page in the navigation bar, create a `MenuItem` entry via the Django admin:
+
+1. Go to `/admin/` → **Menu items** → **Add menu item**.
+2. Set **Label** to the text you want in the nav (e.g. `About`).
+3. Set **URL** to `/<slug>/` matching the page slug.
+4. Set **Order** to control its position relative to other items.
+5. Make sure **Is active** is checked.
+6. Save.
+
+---
+
 ### Blog
 
 Published posts are available at:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ The ORM is allowed at all layers as a pragmatic exception.
 
 ---
 
+## Modules
+
+### Blog
+
+Published posts are available at:
+
+| URL | View | Description |
+|---|---|---|
+| `/blog/` | `PostListView` | Paginated list of all published posts |
+| `/blog/<slug>/` | `PostDetailView` | Full post detail |
+
+Posts are managed via the Django admin (`/admin/` → **Posts**). A post only appears on the site when `is_published` is set to `True`.
+
+#### Adding the Blog to the navigation menu
+
+The navigation bar is driven by `MenuItem` records. To expose the blog page in the menu, create an entry manually via the Django admin:
+
+1. Go to `/admin/` → **Menu items** → **Add menu item**.
+2. Set **Label** to the text you want in the nav (e.g. `Blog`).
+3. Set **URL** to `/blog/`.
+4. Set **Order** to control its position relative to other items.
+5. Make sure **Is active** is checked.
+6. Save.
+
+---
+
 ## Local development with Docker
 
 ### Prerequisites

--- a/src/interface/web/blog/urls.py
+++ b/src/interface/web/blog/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from src.interface.web.blog.views import PostDetailView
+from src.interface.web.blog.views import PostDetailView, PostListView
 
 urlpatterns = [
+    path("", PostListView.as_view(), name="post-list"),
     path("<slug:slug>/", PostDetailView.as_view(), name="post-detail"),
 ]

--- a/src/interface/web/blog/views.py
+++ b/src/interface/web/blog/views.py
@@ -1,7 +1,16 @@
 from django.db.models import QuerySet
-from django.views.generic import DetailView
+from django.views.generic import DetailView, ListView
 
 from src.infrastructure.database.blog.models import Post
+
+
+class PostListView(ListView):  # type: ignore[type-arg]
+    template_name = "blog/post_list.html"
+    context_object_name = "posts"
+    paginate_by = 5
+
+    def get_queryset(self) -> QuerySet[Post]:
+        return Post.objects.filter(is_published=True)
 
 
 class PostDetailView(DetailView):  # type: ignore[type-arg]

--- a/src/interface/web/templates/blog/post_list.html
+++ b/src/interface/web/templates/blog/post_list.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}Blog — {{ site_name }}{% endblock %}
+
+{% block banner %}
+<div class="w-full bg-primary">
+    <div class="max-w-4xl mx-auto px-4 py-12">
+        <h1 class="text-4xl font-bold text-background">Blog</h1>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+{% if posts %}
+<div class="flex flex-col gap-6">
+    {% for post in posts %}
+    <a href="{% url 'post-detail' post.slug %}" class="block border border-border rounded-lg overflow-hidden hover:border-primary transition-colors">
+        {% if post.banner %}
+        <div class="w-full overflow-hidden aspect-[24/5]">
+            <img src="{{ post.banner.url }}" alt="{{ post.title }}" loading="lazy" class="w-full h-full object-cover">
+        </div>
+        {% endif %}
+        <div class="p-6">
+            <h2 class="text-xl font-semibold mb-2">{{ post.title }}</h2>
+            {% if post.excerpt %}
+            <p class="text-muted mb-4">{{ post.excerpt }}</p>
+            {% endif %}
+            {% if post.published_at %}
+            <p class="text-sm text-muted">{{ post.published_at|date:"N j, Y" }}</p>
+            {% endif %}
+        </div>
+    </a>
+    {% endfor %}
+</div>
+
+{% if is_paginated %}
+<nav class="mt-8 flex justify-center gap-2">
+    {% if page_obj.has_previous %}
+    <a href="?page={{ page_obj.previous_page_number }}" class="px-4 py-2 border border-border rounded hover:border-primary transition-colors">&larr;</a>
+    {% endif %}
+    <span class="px-4 py-2 text-muted">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+    <a href="?page={{ page_obj.next_page_number }}" class="px-4 py-2 border border-border rounded hover:border-primary transition-colors">&rarr;</a>
+    {% endif %}
+</nav>
+{% endif %}
+
+{% else %}
+<p class="text-muted">No hay posts publicados todavía.</p>
+{% endif %}
+{% endblock %}

--- a/tests/integration/interface/web/blog/test_views.py
+++ b/tests/integration/interface/web/blog/test_views.py
@@ -3,6 +3,49 @@ from django.test import TestCase
 from src.infrastructure.database.blog.models import Post
 
 
+class PostListViewTest(TestCase):
+    def setUp(self) -> None:
+        self.published_post = Post.objects.create(
+            title="Hello World",
+            slug="hello-world",
+            content="My first post",
+            is_published=True,
+        )
+        self.draft_post = Post.objects.create(
+            title="Draft",
+            slug="draft",
+            content="Not ready",
+            is_published=False,
+        )
+
+    def test_returns_200(self) -> None:
+        response = self.client.get("/blog/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_only_published_posts_appear(self) -> None:
+        response = self.client.get("/blog/")
+        posts = list(response.context["posts"])
+        self.assertIn(self.published_post, posts)
+        self.assertNotIn(self.draft_post, posts)
+
+    def test_uses_post_list_template(self) -> None:
+        response = self.client.get("/blog/")
+        self.assertTemplateUsed(response, "blog/post_list.html")
+
+    def test_pagination(self) -> None:
+        for i in range(10):
+            Post.objects.create(
+                title=f"Post {i}",
+                slug=f"post-{i}",
+                content="content",
+                is_published=True,
+            )
+        response = self.client.get("/blog/")
+        self.assertTrue(response.context["is_paginated"])
+        response_p2 = self.client.get("/blog/?page=2")
+        self.assertEqual(response_p2.status_code, 200)
+
+
 class PostDetailViewTest(TestCase):
     def setUp(self) -> None:
         self.published_post = Post.objects.create(

--- a/truqui_center/urls.py
+++ b/truqui_center/urls.py
@@ -23,8 +23,8 @@ from django.urls import URLPattern, URLResolver, include, path
 urlpatterns: list[URLPattern | URLResolver] = [
     path("admin/", admin.site.urls),
     path("", include("src.interface.web.urls")),
-    path("", include("src.interface.web.page.urls")),
     path("blog/", include("src.interface.web.blog.urls")),
+    path("", include("src.interface.web.page.urls")),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Summary

Adds a paginated blog post listing page at `/blog/` where users can discover all published posts and navigate to each one.

## Solution

- Added `PostListView` (Django `ListView`) at `/blog/` showing published posts ordered by `published_at` descending, paginated (5 per page).
- Created `blog/post_list.html` template with a primary-color banner header and post cards (banner thumbnail, title, excerpt, date).
- Fixed URL ordering in `truqui_center/urls.py`: `blog/` include must come before the catch-all page `<slug:slug>/` include to avoid `/blog/` being swallowed by the pages router.
- Added integration tests for `PostListView` (status 200, published-only filter, template, pagination).
- Documented the Pages and Blog modules in the README, including steps to add them to the navigation menu via Django admin.

## Related issue

Closes #27

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Docs / config

## Checklist

- [x] Tests pass
- [ ] Manually tested the change
- [x] No unintended side effects on other features